### PR TITLE
Fix CI failing on package installation

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Dependencies
-      run: sudo apt install -y pandoc texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-luatex fonts-dejavu python3-pygments
+      run: sudo apt update && sudo apt install -y pandoc texlive-latex-base texlive-latex-extra texlive-latex-recommended texlive-luatex fonts-dejavu python3-pygments
 
     - name: Download the Book Template
       run: |


### PR DESCRIPTION
`apt update` was missing (and needed as package indices drift out of date).