### PR TITLE
No default target in lakefile

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,15 +1,12 @@
 import Lake
 open Lake DSL
 
-package «lean4-metaprogramming-book» {
-  srcDir := ⟨"lean"⟩
-}
+package «lean4-metaprogramming-book» where
+  srcDir := "lean"
 
-@[default_target]
-lean_lib «lean4-metaprogramming-book» {
+lean_lib «lean4-metaprogramming-book» where
   roots := #[`cover, `extra, `main, `solutions]
   globs := #[Glob.one `cover, Glob.submodules `extra, Glob.submodules `main, Glob.submodules `solutions]
-}
 
 def runCmd (cmd : String) (args : Array String) : ScriptM Bool := do
   let out ← IO.Process.output {


### PR DESCRIPTION
Remove the `@[default_target]` attribute from the `lean4-metaprogramming-book` library. This prevents it from being automatically built on a `lake build`, which does not work because it just builds all the code in the book (incuding errors). This will help prevent [Reservoir](https://reservoir.lean-lang.org/) from giving the book a red cross.

Also uses the now-more-standard `where` syntax rather than braces for the configurations.