### PR TITLE
bug fix: invalid runCmd arguments

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -22,5 +22,5 @@ def runCmd (cmd : String) (args : Array String) : ScriptM Bool := do
   return hasError
 
 script build do
-  if ← runCmd "lake exe mdgen" #["lean", "md"] then return 1
+  if ← runCmd "lake" #["exe", "mdgen", "lean", "md"] then return 1
   return 0


### PR DESCRIPTION
Fixes a problem with `lake run build` not working on macOS and Unix.

see https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mdbook.20setup.20template.20for.20Lean.20project