### PR TITLE
Add `set_option pp.explicit false` in Weak Head Normal Form example

### DIFF
--- a/lean/main/04_metam.lean
+++ b/lean/main/04_metam.lean
@@ -639,6 +639,7 @@ Now, here are some examples of expressions in WHNF.
 Constructor applications are in WHNF (with some exceptions for numeric types):
 -/
 
+set_option pp.explicit false
 #eval whnf' `(List.cons 1 [])
 -- [1]
 

--- a/lean/main/04_metam.lean
+++ b/lean/main/04_metam.lean
@@ -566,7 +566,7 @@ we can see that the `+` notation amounts to an application of the `hAdd`
 function, which is a member of the `HAdd` typeclass:
 -/
 
-set_option pp.explicit true
+set_option pp.explicit true in
 #eval traceConstWithTransparency .reducible ``reducibleDef
 -- @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) defaultDef 1
 
@@ -639,7 +639,6 @@ Now, here are some examples of expressions in WHNF.
 Constructor applications are in WHNF (with some exceptions for numeric types):
 -/
 
-set_option pp.explicit false
 #eval whnf' `(List.cons 1 [])
 -- [1]
 


### PR DESCRIPTION
In the following example in [Weak Head Normalisation](https://leanprover-community.github.io/lean4-metaprogramming-book/main/04_metam.html#weak-head-normalisation) section:

the expected output is:
```
#eval whnf' `(List.cons 1 [])
-- [1]
```
but the actual output is:
```
#eval whnf' `(List.cons 1 [])
-- @List.cons Nat 1 (@List.nil Nat)
```
This PR fixes the example code so that the actual output matches the one in the book.