### PR TITLE
upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload PDF to artifact storage
       if: github.ref != 'refs/heads/master'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: "Metaprogramming in Lean 4"
         path: "Metaprogramming in Lean 4.pdf"


### PR DESCRIPTION
I got an email from GitHub saying v3 will be deprecated in December, so I figured I'd do this for repos under leanprover-community before I forgot.