### PR TITLE
chore: Use `Option.get` instead of `Options.get`

### DIFF
--- a/lean/extra/01_options.lean
+++ b/lean/extra/01_options.lean
@@ -55,13 +55,12 @@ As of now, it is implemented by:
 - `LevelElabM`
 - all monads to which you can lift operations of one of the above (e.g. `MetaM` from `CoreM`)
 
-Once we have an `Options` object, we can query the information via `Options.get`.
+Once we have an `Options` object, we can query the information via `Option.get`.
 To show this, let's write a command that prints the value of `pp.explicit`.
 -/
 elab "#getPPExplicit" : command => do
   let opts ← getOptions
-  -- defValue = default value
-  logInfo s!"pp.explicit : {opts.get pp.explicit.name pp.explicit.defValue}"
+  logInfo s!"pp.explicit : {pp.explicit.get opts}"
 
 #getPPExplicit -- pp.explicit : false
 


### PR DESCRIPTION
The implemention of `Option.get` is exactly what was written here.