### PR TITLE
feat: add file play button

### DIFF
--- a/assets/filePlay.js
+++ b/assets/filePlay.js
@@ -1,0 +1,27 @@
+/** Modifies the "Suggest an edit" button of mdbook,
+
+* changing it to a link to the Lean4 web editor.
+* Note that the modification is done on the HTML side to prevent the original icon from appearing for a moment.
+*/
+function filePlay() {
+  const playButtonIcon = document.querySelector("#lean-play-button");
+
+  const playButtonLink = playButtonIcon.parentElement;
+
+  playButtonLink.href = playButtonLink.href.replace(/\.md$/, ".lean");
+
+  playButtonLink.href = playButtonLink.href.replace(
+    "/md/",
+    "/lean/",
+  );
+
+  fetch(playButtonLink.href)
+    .then((response) => response.text())
+    .then((body) => {
+      const escaped_code = encodeURIComponent(body);
+      const url = `https://live.lean-lang.org/#code=${escaped_code}`;
+      playButtonLink.href = url;
+    });
+}
+
+filePlay();

--- a/book.toml
+++ b/book.toml
@@ -12,3 +12,6 @@ additional-js = [
   "assets/blockPlay.js",
   "assets/pagetoc.js"
 ]
+
+# To ensure that the 404 page functions properly.
+site-url = "https://leanprover-community.github.io/lean4-metaprogramming-book/"

--- a/book.toml
+++ b/book.toml
@@ -10,8 +10,12 @@ git-repository-url = "https://github.com/leanprover-community/lean4-metaprogramm
 additional-css = ["./assets/pagetoc.css"]
 additional-js = [
   "assets/blockPlay.js",
-  "assets/pagetoc.js"
+  "assets/filePlay.js",
+  "assets/pagetoc.js",
 ]
+
+# Settings to overwrite the edit button and make it a code execution button.
+edit-url-template = "https://raw.githubusercontent.com/leanprover-community/lean4-metaprogramming-book/master/{path}"
 
 # To ensure that the 404 page functions properly.
 site-url = "https://leanprover-community.github.io/lean4-metaprogramming-book/"


### PR DESCRIPTION
Add an execute button to the top right of each page. When this button is clicked, it allows the .lean file that the page is based on to be executed in the Lean 4 web editor.

![image](https://github.com/user-attachments/assets/a57446ca-6b01-4b9a-ac36-c807053deb31)
