### PR TITLE
test: assert metaprogramming examples output

### DIFF
--- a/lean/extra/01_options.lean
+++ b/lean/extra/01_options.lean
@@ -19,10 +19,19 @@ with your program is quite simple with the `set_option` command:
 import Lean
 open Lean
 
+/--
+info: 1 + 1 : Nat
+-/
+#guard_msgs in --#
 #check 1 + 1 -- 1 + 1 : Nat
 
 set_option pp.explicit true -- No custom syntax in pretty printing
 
+/--
+info: @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) (@OfNat.ofNat Nat 1 (instOfNatNat 1))
+  (@OfNat.ofNat Nat 1 (instOfNatNat 1)) : Nat
+-/
+#guard_msgs in --#
 #check 1 + 1 -- @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) 1 1 : Nat
 
 set_option pp.explicit false
@@ -32,10 +41,51 @@ You can furthermore limit an option value to just the next command or term:
 -/
 
 set_option pp.explicit true in
+/--
+info: @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) (@OfNat.ofNat Nat 1 (instOfNatNat 1))
+  (@OfNat.ofNat Nat 1 (instOfNatNat 1)) : Nat
+-/
+#guard_msgs in --#
 #check 1 + 1 -- @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) 1 1 : Nat
 
+/--
+info: 1 + 1 : Nat
+-/
+#guard_msgs in --#
 #check 1 + 1 -- 1 + 1 : Nat
 
+/--
+info: 1 + 1 : Nat
+---
+info: [Meta.synthInstance] 💥️ OfNat ?m.417 1
+  [Meta.synthInstance] new goal OfNat ?m.417 1
+    [Meta.synthInstance.instances] #[@Json.instOfNat, @instOfNatInt16, @UInt64.instOfNat, @JsonNumber.instOfNat, @instOfNatInt8, @instOfNatFloat, @BitVec.instOfNat, @instOfNatInt64, Level.instOfNat, @instOfNat, @Id.instOfNat, @Std.Internal.Rat.instOfNat, @UInt16.instOfNat, instOfNatNat, @UInt32.instOfNat, @JsonRpc.instOfNatRequestID, @UInt8.instOfNat, @Fin.instOfNat, @instOfNatISize, @instOfNatFloat32, @instOfNatInt32, @USize.instOfNat]
+  [Meta.synthInstance] 💥️ apply @USize.instOfNat to OfNat ?m.417 1
+    [Meta.synthInstance.tryResolve] 💥️ OfNat ?m.417 1 ≟ OfNat USize ?m.422
+[Meta.synthInstance] 💥️ OfNat ?m.417 1
+  [Meta.synthInstance] new goal OfNat ?m.417 1
+    [Meta.synthInstance.instances] #[@Json.instOfNat, @instOfNatInt16, @UInt64.instOfNat, @JsonNumber.instOfNat, @instOfNatInt8, @instOfNatFloat, @BitVec.instOfNat, @instOfNatInt64, Level.instOfNat, @instOfNat, @Id.instOfNat, @Std.Internal.Rat.instOfNat, @UInt16.instOfNat, instOfNatNat, @UInt32.instOfNat, @JsonRpc.instOfNatRequestID, @UInt8.instOfNat, @Fin.instOfNat, @instOfNatISize, @instOfNatFloat32, @instOfNatInt32, @USize.instOfNat]
+  [Meta.synthInstance] 💥️ apply @USize.instOfNat to OfNat ?m.417 1
+    [Meta.synthInstance.tryResolve] 💥️ OfNat ?m.417 1 ≟ OfNat USize ?m.436
+---
+info: [Meta.synthInstance] 💥️ HAdd ?m.440 ?m.441 ?m.442
+  [Meta.synthInstance] new goal HAdd ?m.440 ?m.441 _tc.0
+    [Meta.synthInstance.instances] #[@instHAdd, instHAddPosString, instHAddPos, instHAddPosChar]
+  [Meta.synthInstance] 💥️ apply instHAddPosChar to HAdd ?m.440 ?m.441 ?m.444
+    [Meta.synthInstance.tryResolve] 💥️ HAdd ?m.440 ?m.441 ?m.444 ≟ HAdd String.Pos Char String.Pos
+---
+info: [Meta.synthInstance] 💥️ OfNat ?m.426 1
+  [Meta.synthInstance] new goal OfNat ?m.426 1
+    [Meta.synthInstance.instances] #[@Json.instOfNat, @instOfNatInt16, @UInt64.instOfNat, @JsonNumber.instOfNat, @instOfNatInt8, @instOfNatFloat, @BitVec.instOfNat, @instOfNatInt64, Level.instOfNat, @instOfNat, @Id.instOfNat, @Std.Internal.Rat.instOfNat, @UInt16.instOfNat, instOfNatNat, @UInt32.instOfNat, @JsonRpc.instOfNatRequestID, @UInt8.instOfNat, @Fin.instOfNat, @instOfNatISize, @instOfNatFloat32, @instOfNatInt32, @USize.instOfNat]
+  [Meta.synthInstance] 💥️ apply @USize.instOfNat to OfNat ?m.426 1
+    [Meta.synthInstance.tryResolve] 💥️ OfNat ?m.426 1 ≟ OfNat USize ?m.431
+[Meta.synthInstance] 💥️ OfNat ?m.426 1
+  [Meta.synthInstance] new goal OfNat ?m.426 1
+    [Meta.synthInstance.instances] #[@Json.instOfNat, @instOfNatInt16, @UInt64.instOfNat, @JsonNumber.instOfNat, @instOfNatInt8, @instOfNatFloat, @BitVec.instOfNat, @instOfNatInt64, Level.instOfNat, @instOfNat, @Id.instOfNat, @Std.Internal.Rat.instOfNat, @UInt16.instOfNat, instOfNatNat, @UInt32.instOfNat, @JsonRpc.instOfNatRequestID, @UInt8.instOfNat, @Fin.instOfNat, @instOfNatISize, @instOfNatFloat32, @instOfNatInt32, @USize.instOfNat]
+  [Meta.synthInstance] 💥️ apply @USize.instOfNat to OfNat ?m.426 1
+    [Meta.synthInstance.tryResolve] 💥️ OfNat ?m.426 1 ≟ OfNat USize ?m.439
+-/
+#guard_msgs in --#
 #check set_option trace.Meta.synthInstance true in 1 + 1 -- the trace of the type class synthesis for `OfNat` and `HAdd`
 
 /-!

--- a/lean/extra/03_pretty-printing.lean
+++ b/lean/extra/03_pretty-printing.lean
@@ -55,7 +55,15 @@ def foo : Nat → Nat := fun x => 42
 def delabFoo : Delab := do
   `(1)
 
+/--
+info: 1 : Nat → Nat
+-/
+#guard_msgs in --#
 #check (foo) -- 1 : Nat → Nat
+/--
+info: 1 : Nat
+-/
+#guard_msgs in --#
 #check foo 13 -- 1 : Nat, full applications are also pretty printed this way
 
 /-!
@@ -68,6 +76,10 @@ attributes we can also overload delaborators:
 def delabfoo2 : Delab := do
   `(2)
 
+/--
+info: 2 : Nat → Nat
+-/
+#guard_msgs in --#
 #check (foo) -- 2 : Nat → Nat
 
 /-!
@@ -82,6 +94,10 @@ def delabfoo3 : Delab := do
   failure
   `(3)
 
+/--
+info: 2 : Nat → Nat
+-/
+#guard_msgs in --#
 #check (foo) -- 2 : Nat → Nat, still 2 since 3 failed
 
 /-!
@@ -97,7 +113,15 @@ def delabfooFinal : Delab := do
   let arg ← withAppArg delab
   `($fn $arg)
 
+/--
+info: fooSpecial 42 : Nat
+-/
+#guard_msgs in --#
 #check foo 42 -- fooSpecial 42 : Nat
+/--
+info: 2 : Nat → Nat
+-/
+#guard_msgs in --#
 #check (foo) -- 2 : Nat → Nat, still 2 since 3 failed
 
 /-!
@@ -133,7 +157,15 @@ def unexpMyId : Unexpander
   | `($_myid $arg) => set_option hygiene false in `(id $arg)
   | `($_myid) => pure $ mkIdent `id
 
+/--
+info: id 12 : Nat
+-/
+#guard_msgs in --#
 #check myid 12 -- id 12 : Nat
+/--
+info: id : ?m.4215 → ?m.4215
+-/
+#guard_msgs in --#
 #check (myid) -- id : ?m.3870 → ?m.3870
 
 /-!
@@ -154,6 +186,10 @@ def unexpRemoveId : Unexpander
   | `($_removeId (id $arg)) => pure arg
   | _ => throw ()
 
+/--
+info: removeId (id 42) : Nat
+-/
+#guard_msgs in --#
 #check removeId (id 42) -- removeId (id 42) : Nat
 
 /-!
@@ -170,6 +206,10 @@ def unexpRemoveId' : Unexpander
       | _ => throw ()
   | _ => throw ()
 
+/--
+info: 42 : Nat
+-/
+#guard_msgs in --#
 #check removeId' (id 42) -- 42 : Nat
 
 /-!
@@ -205,6 +245,11 @@ instance : Coe Ident (TSyntax `lang) where
 
 -- LangExpr.letE "foo" (LangExpr.numConst 12)
 --   (LangExpr.letE "bar" (LangExpr.ident "foo") (LangExpr.ident "foo")) : LangExpr
+/--
+info: LangExpr.letE "foo" (LangExpr.numConst 12)
+  (LangExpr.letE "bar" (LangExpr.ident "foo") (LangExpr.ident "foo")) : LangExpr
+-/
+#guard_msgs in --#
 #check [Lang|
   let foo := 12 in
   let bar := foo in
@@ -238,11 +283,19 @@ def unexpandLet : Unexpander
   | _ => throw ()
 
 -- [Lang| let foo := 12 in foo] : LangExpr
+/--
+info: [Lang| let foo := 12 in foo] : LangExpr
+-/
+#guard_msgs in --#
 #check [Lang|
   let foo := 12 in foo
 ]
 
 -- [Lang| let foo := 12 in let bar := foo in foo] : LangExpr
+/--
+info: [Lang| let foo := 12 in let bar := foo in foo] : LangExpr
+-/
+#guard_msgs in --#
 #check [Lang|
   let foo := 12 in
   let bar := foo in

--- a/lean/main/01_intro.lean
+++ b/lean/main/01_intro.lean
@@ -101,12 +101,12 @@ import Lean
 macro x:ident ":" t:term " ↦ " y:term : term => do
   `(fun $x : $t => $y)
 
-#eval (x : Nat ↦ x + 2) 2 -- 4
+#guard reprStr ((x : Nat ↦ x + 2) 2) == "4" -- 4
 
 macro x:ident " ↦ " y:term : term => do
   `(fun $x  => $y)
 
-#eval (x ↦  x + 2) 2 -- 4
+#guard reprStr ((x ↦  x + 2) 2) == "4" -- 4
 /-!
 
 ### Building a command
@@ -207,21 +207,45 @@ macro_rules
   | `(⟪ $x:arith * $y:arith ⟫) => `(Arith.mul ⟪ $x ⟫ ⟪ $y ⟫)
   | `(⟪ ( $x ) ⟫)              => `( ⟪ $x ⟫ )
 
+/--
+info: (Arith.var "x").mul (Arith.var "y") : Arith
+-/
+#guard_msgs in --#
 #check ⟪ "x" * "y" ⟫
 -- Arith.mul (Arith.var "x") (Arith.var "y") : Arith
 
+/--
+info: (Arith.var "x").add (Arith.var "y") : Arith
+-/
+#guard_msgs in --#
 #check ⟪ "x" + "y" ⟫
 -- Arith.add (Arith.var "x") (Arith.var "y") : Arith
 
+/--
+info: (Arith.var "x").add (Arith.nat 20) : Arith
+-/
+#guard_msgs in --#
 #check ⟪ "x" + 20 ⟫
 -- Arith.add (Arith.var "x") (Arith.nat 20) : Arith
 
+/--
+info: (Arith.var "x").add ((Arith.var "y").mul (Arith.var "z")) : Arith
+-/
+#guard_msgs in --#
 #check ⟪ "x" + "y" * "z" ⟫ -- precedence
 -- Arith.add (Arith.var "x") (Arith.mul (Arith.var "y") (Arith.var "z")) : Arith
 
+/--
+info: ((Arith.var "x").mul (Arith.var "y")).add (Arith.var "z") : Arith
+-/
+#guard_msgs in --#
 #check ⟪ "x" * "y" + "z" ⟫ -- precedence
 -- Arith.add (Arith.mul (Arith.var "x") (Arith.var "y")) (Arith.var "z") : Arith
 
+/--
+info: ((Arith.var "x").add (Arith.var "y")).mul (Arith.var "z") : Arith
+-/
+#guard_msgs in --#
 #check ⟪ ("x" + "y") * "z" ⟫ -- brackets
 -- Arith.mul (Arith.add (Arith.var "x") (Arith.var "y")) (Arith.var "z")
 

--- a/lean/main/03_expressions.lean
+++ b/lean/main/03_expressions.lean
@@ -186,6 +186,10 @@ as the `pp.universes` pretty-printing option shows:
 -/
 
 set_option pp.universes true in
+/--
+info: @List.map.{u_1, u_2} : {α : Type u_1} → {β : Type u_2} → (α → β) → List.{u_1} α → List.{u_2} β
+-/
+#guard_msgs in --#
 #check @List.map
 
 /-!
@@ -219,10 +223,10 @@ which is useful to avoid typos.
 open Lean
 
 def z' := Expr.const `Nat.zero []
-#eval z' -- Lean.Expr.const `Nat.zero []
+#guard reprStr (z') == "Lean.Expr.const `Nat.zero []" -- Lean.Expr.const `Nat.zero []
 
 def z := Expr.const ``Nat.zero []
-#eval z -- Lean.Expr.const `Nat.zero []
+#guard reprStr (z) == "Lean.Expr.const `Nat.zero []" -- Lean.Expr.const `Nat.zero []
 
 /-
 The double-backtick variant also resolves the given name, making it fully-qualified.
@@ -237,10 +241,10 @@ contains the fully-qualified name `Nat.zero` and does not have this problem.
 open Nat
 
 def z₁ := Expr.const `zero []
-#eval z₁ -- Lean.Expr.const `zero []
+#guard reprStr (z₁) == "Lean.Expr.const `zero []" -- Lean.Expr.const `zero []
 
 def z₂ := Expr.const ``zero []
-#eval z₂ -- Lean.Expr.const `Nat.zero []
+#guard reprStr (z₂) == "Lean.Expr.const `Nat.zero []" -- Lean.Expr.const `Nat.zero []
 
 /-
 ### Function Applications
@@ -256,7 +260,7 @@ The second is a recursive definition giving an expression as a function of a nat
 -/
 
 def one := Expr.app (.const ``Nat.succ []) z
-#eval one
+#guard reprStr (one) == "Lean.Expr.app (Lean.Expr.const `Nat.succ []) (Lean.Expr.const `Nat.zero [])"
 -- Lean.Expr.app (Lean.Expr.const `Nat.succ []) (Lean.Expr.const `Nat.zero [])
 
 def natExpr: Nat → Expr
@@ -286,7 +290,7 @@ The argument `BinderInfo.default` says that `x` is an explicit argument
 def constZero : Expr :=
   .lam `x (.const ``Nat []) (.const ``Nat.zero []) BinderInfo.default
 
-#eval constZero
+#guard reprStr (constZero) == "Lean.Expr.lam `x (Lean.Expr.const `Nat []) (Lean.Expr.const `Nat.zero []) (Lean.BinderInfo.default)"
 -- Lean.Expr.lam `x (Lean.Expr.const `Nat []) (Lean.Expr.const `Nat.zero [])
 --   (Lean.BinderInfo.default)
 
@@ -314,11 +318,19 @@ we can turn our `Expr` into a Lean term, which allows us to inspect it more easi
 
 elab "mapAddOneNil" : term => return mapAddOneNil
 
+/--
+info: List.map (fun x => x.add 1) [] : List Nat
+-/
+#guard_msgs in --#
 #check mapAddOneNil
 -- List.map (fun x => Nat.add x 1) [] : List Nat
 
 set_option pp.universes true in
 set_option pp.explicit true in
+/--
+info: @List.map.{0, 0} Nat Nat (fun x => x.add (@OfNat.ofNat.{0} Nat 1 (instOfNatNat 1))) (@List.nil.{0} Nat) : List.{0} Nat
+-/
+#guard_msgs in --#
 #check mapAddOneNil
 -- @List.map.{0, 0} Nat Nat (fun x => x.add 1) (@List.nil.{0} Nat) : List.{0} Nat
 

--- a/lean/main/04_metam.lean
+++ b/lean/main/04_metam.lean
@@ -243,6 +243,25 @@ metavariable operations are used. More natural examples appear in the following
 sections.
 -/
 
+/--
+info: Initially, all metavariables are unassigned:
+  meta1: ?_uniq.2172
+  meta2: ?_uniq.2173
+  meta3: ?_uniq.2174
+After assigning mvar1:
+  meta1: ?_uniq.2174 ?_uniq.2173
+  meta2: ?_uniq.2173
+  meta3: ?_uniq.2174
+After assigning mvar2:
+  meta1: ?_uniq.2174 Nat.zero
+  meta2: Nat.zero
+  meta3: ?_uniq.2174
+After assigning mvar3:
+  meta1: Nat.succ Nat.zero
+  meta2: Nat.zero
+  meta3: Nat.succ
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   -- Create two fresh metavariables of type `Nat`.
   let mvar1 ← mkFreshExprMVar (Expr.const ``Nat []) (userName := `mvar1)
@@ -490,9 +509,17 @@ We can use it like this:
 
 def someNumber : Nat := (· + 2) $ 3
 
+/--
+info: Lean.Expr.const `someNumber []
+-/
+#guard_msgs in --#
 #eval Expr.const ``someNumber []
 -- Lean.Expr.const `someNumber []
 
+/--
+info: Lean.Expr.lit (Lean.Literal.natVal 5)
+-/
+#guard_msgs in --#
 #eval reduce (Expr.const ``someNumber [])
 -- Lean.Expr.lit (Lean.Literal.natVal 5)
 
@@ -557,6 +584,10 @@ abbrev             reducibleDef   : Nat      := defaultDef + 1
 We start with `reducible` transparency, which only unfolds `reducibleDef`:
 -/
 
+/--
+info: defaultDef + 1
+-/
+#guard_msgs in --#
 #eval traceConstWithTransparency .reducible ``reducibleDef
 -- defaultDef + 1
 
@@ -567,6 +598,10 @@ function, which is a member of the `HAdd` typeclass:
 -/
 
 set_option pp.explicit true in
+/--
+info: @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) defaultDef (@OfNat.ofNat Nat 1 (instOfNatNat 1))
+-/
+#guard_msgs in --#
 #eval traceConstWithTransparency .reducible ``reducibleDef
 -- @HAdd.hAdd Nat Nat Nat (@instHAdd Nat instAddNat) defaultDef 1
 
@@ -575,6 +610,10 @@ When we reduce with `instances` transparency, this applications is unfolded and
 replaced by `Nat.add`:
 -/
 
+/--
+info: defaultDef.add 1
+-/
+#guard_msgs in --#
 #eval traceConstWithTransparency .instances ``reducibleDef
 -- Nat.add defaultDef 1
 
@@ -582,6 +621,10 @@ replaced by `Nat.add`:
 With `default` transparency, `Nat.add` is unfolded as well:
 -/
 
+/--
+info: irreducibleDef.succ.succ
+-/
+#guard_msgs in --#
 #eval traceConstWithTransparency .default ``reducibleDef
 -- Nat.succ (Nat.succ irreducibleDef)
 
@@ -589,6 +632,10 @@ With `default` transparency, `Nat.add` is unfolded as well:
 And with `TransparencyMode.all`, we're finally able to unfold `irreducibleDef`:
 -/
 
+/--
+info: 3
+-/
+#guard_msgs in --#
 #eval traceConstWithTransparency .all ``reducibleDef
 -- 3
 
@@ -639,6 +686,10 @@ Now, here are some examples of expressions in WHNF.
 Constructor applications are in WHNF (with some exceptions for numeric types):
 -/
 
+/--
+info: [1]
+-/
+#guard_msgs in --#
 #eval whnf' `(List.cons 1 [])
 -- [1]
 
@@ -646,6 +697,10 @@ Constructor applications are in WHNF (with some exceptions for numeric types):
 The *arguments* of an application in WHNF may or may not be in WHNF themselves:
 -/
 
+/--
+info: [1 + 1]
+-/
+#guard_msgs in --#
 #eval whnf' `(List.cons (1 + 1) [])
 -- [1 + 1]
 
@@ -654,6 +709,10 @@ Applications of constants are in WHNF if the current transparency does not
 allow us to unfold the constants:
 -/
 
+/--
+info: [1].append [2]
+-/
+#guard_msgs in --#
 #eval withTransparency .reducible $ whnf' `(List.append [1] [2])
 -- List.append [1] [2]
 
@@ -661,6 +720,10 @@ allow us to unfold the constants:
 Lambdas are in WHNF:
 -/
 
+/--
+info: fun x => x
+-/
+#guard_msgs in --#
 #eval whnf' `(λ x : Nat => x)
 -- fun x => x
 
@@ -668,6 +731,10 @@ Lambdas are in WHNF:
 Foralls are in WHNF:
 -/
 
+/--
+info: ∀ (x : Nat), x > 0
+-/
+#guard_msgs in --#
 #eval whnf' `(∀ x, x > 0)
 -- ∀ (x : Nat), x > 0
 
@@ -675,6 +742,10 @@ Foralls are in WHNF:
 Sorts are in WHNF:
 -/
 
+/--
+info: Type 3
+-/
+#guard_msgs in --#
 #eval whnf' `(Type 3)
 -- Type 3
 
@@ -682,6 +753,10 @@ Sorts are in WHNF:
 Literals are in WHNF:
 -/
 
+/--
+info: 15
+-/
+#guard_msgs in --#
 #eval whnf' `((15 : Nat))
 -- 15
 
@@ -699,6 +774,10 @@ Applications of constants are not in WHNF if the current transparency allows us
 to unfold the constants:
 -/
 
+/--
+info: fun x => 1 :: [].append x
+-/
+#guard_msgs in --#
 #eval whnf' `(List.append [1])
 -- fun x => 1 :: List.append [] x
 
@@ -706,6 +785,10 @@ to unfold the constants:
 Applications of lambdas are not in WHNF:
 -/
 
+/--
+info: fun y => 1 + y
+-/
+#guard_msgs in --#
 #eval whnf' `((λ x y : Nat => x + y) 1)
 -- `fun y => 1 + y`
 
@@ -713,6 +796,10 @@ Applications of lambdas are not in WHNF:
 `let` bindings are not in WHNF:
 -/
 
+/--
+info: 1
+-/
+#guard_msgs in --#
 #eval whnf' `(let x : Nat := 1; x)
 -- 1
 
@@ -886,6 +973,10 @@ def revOrd : Ord Nat where
 def ordExpr : MetaM Expr := do
   mkAppOptM ``compare #[none, Expr.const ``revOrd [], mkNatLit 0, mkNatLit 1]
 
+/--
+info: Ord.compare.{0} Nat revOrd (OfNat.ofNat.{0} Nat 0 (instOfNatNat 0)) (OfNat.ofNat.{0} Nat 1 (instOfNatNat 1))
+-/
+#guard_msgs in --#
 #eval format <$> ordExpr
 -- Ord.compare.{0} Nat revOrd
 --   (OfNat.ofNat.{0} Nat 0 (instOfNatNat 0))
@@ -909,6 +1000,10 @@ def doubleExpr₁ : Expr :=
   .lam `x (.const ``Nat []) (mkAppN (.const ``Nat.add []) #[.bvar 0, .bvar 0])
     BinderInfo.default
 
+/--
+info: fun x => x.add x
+-/
+#guard_msgs in --#
 #eval ppExpr doubleExpr₁
 -- fun x => Nat.add x x
 
@@ -946,6 +1041,10 @@ def doubleExpr₂ : MetaM Expr :=
     let body ← mkAppM ``Nat.add #[x, x]
     mkLambdaFVars #[x] body
 
+/--
+info: fun x => x.add x
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← doubleExpr₂)
 -- fun x => Nat.add x x
@@ -1009,6 +1108,10 @@ are discussed in the Elaboration chapter.
 
 elab "someProp" : term => somePropExpr
 
+/--
+info: fun f => ∀ (n : Nat), f n = f n.succ : (Nat → Nat) → Prop
+-/
+#guard_msgs in --#
 #check someProp
 -- fun f => ∀ (n : Nat), f n = f (Nat.succ n) : (Nat → Nat) → Prop
 #reduce someProp Nat.succ
@@ -1215,6 +1318,7 @@ Notice that changing the type of the metavariable from `Nat` to, for example, `S
 3. [**Metavariables**] Fill in the missing lines in the following code.
 
     ```lean
+    #guard_msgs in --#
     #eval show MetaM Unit from do
       let oneExpr := Expr.app (Expr.const `Nat.succ []) (Expr.const ``Nat.zero [])
       let twoExpr := Expr.app (Expr.const `Nat.succ []) oneExpr
@@ -1278,6 +1382,7 @@ Notice that changing the type of the metavariable from `Nat` to, for example, `S
 
     @[reducible] def sum := [reducibleDef, instanceDef, defaultDef, irreducibleDef]
 
+    #guard_msgs in --#
     #eval show MetaM Unit from do
       let constantExpr := Expr.const `sum []
 
@@ -1313,6 +1418,7 @@ Notice that changing the type of the metavariable from `Nat` to, for example, `S
 14. [**Constructing Expressions**] What would you expect the output of the following code to be?
 
     ```lean
+    #guard_msgs in --#
     #eval show Lean.Elab.Term.TermElabM _ from do
       let stx : Syntax ← `(∀ (a : Prop) (b : Prop), a ∨ b → b → a ∧ a)
       let expr ← Elab.Term.elabTermAndSynthesize stx none

--- a/lean/main/05_syntax.lean
+++ b/lean/main/05_syntax.lean
@@ -18,18 +18,18 @@ import Lean
 -- XOR, denoted \oplus
 infixl:60 " ⊕ " => fun l r => (!l && r) || (l && !r)
 
-#eval true ⊕ true -- false
-#eval true ⊕ false -- true
-#eval false ⊕ true -- true
-#eval false ⊕ false -- false
+#guard reprStr (true ⊕ true) == "false" -- false
+#guard reprStr (true ⊕ false) == "true" -- true
+#guard reprStr (false ⊕ true) == "true" -- true
+#guard reprStr (false ⊕ false) == "false" -- false
 
 -- with `notation`, "left XOR"
 notation:10 l:10 " LXOR " r:11 => (!l && r)
 
-#eval true LXOR true -- false
-#eval true LXOR false -- false
-#eval false LXOR true -- true
-#eval false LXOR false -- false
+#guard reprStr (true LXOR true) == "false" -- false
+#guard reprStr (true LXOR false) == "false" -- false
+#guard reprStr (false LXOR true) == "true" -- true
+#guard reprStr (false LXOR false) == "false" -- false
 
 /- As we can see the `infixl` command allows us to declare a notation for
 a binary operation that is infix, meaning that the operator is in between
@@ -52,9 +52,9 @@ The two unintuitive parts about these two are:
   precedence, meaning how strong they bind to their arguments, let's see this in action:
 -/
 
-#eval true ⊕ false LXOR false -- false
-#eval (true ⊕ false) LXOR false -- false
-#eval true ⊕ (false LXOR false) -- true
+#guard reprStr (true ⊕ false LXOR false) == "false" -- false
+#guard reprStr ((true ⊕ false) LXOR false) == "false" -- false
+#guard reprStr (true ⊕ (false LXOR false)) == "true" -- true
 
 /-!
 As we can see, the Lean interpreter analyzed the first term without parentheses
@@ -108,7 +108,7 @@ Lean attempts to find the longest parse possible. As a general rule of thumb:
 If precedence is ambiguous Lean will default to right associativity.
 -/
 
-#eval 5 ~ 3 ~ 3 -- 5 because this is parsed as 5 - (3 - 3)
+#guard reprStr (5 ~ 3 ~ 3) == "5" -- 5 because this is parsed as 5 - (3 - 3)
 
 /-!
 Lastly, if we define overlapping notation such as:
@@ -123,6 +123,10 @@ then erroring because it doesn't know what to do with `mod` and the
 relation argument:
 -/
 
+/--
+info: 0 = 0 : Prop
+-/
+#guard_msgs in --#
 #check 0 ~ 0 mod Eq -- 0 = 0 : Prop
 
 /-!
@@ -207,6 +211,7 @@ disconnected from the rest of the system. And these cannot be used in place of
 terms anymore:
 
 ```lean
+#guard_msgs in --#
 #check ⊥ AND ⊤ -- expected term
 ```
 -/
@@ -279,7 +284,9 @@ add this to the `term` category:
 
 ```lean
 syntax "bin(" binNumber ")" : term
+#guard_msgs in --#
 #check bin(Z, O, Z, Z, O) -- elaboration function hasn't been implemented but parsing passes
+#guard_msgs in --#
 #check bin() -- fails to parse because `binNumber` is "one or many": expected 'O' or 'Z'
 ```
 -/
@@ -356,6 +363,10 @@ we most definitely want to avoid. Luckily for us there is quite an extensive API
 -/
 
 open Lean
+/--
+info: Lean.Syntax : Type
+-/
+#guard_msgs in --#
 #check Syntax -- Syntax. autocomplete
 
 /-!
@@ -367,8 +378,8 @@ Let's see a few examples:
 -/
 
 -- Name literals are written with this little ` in front of the name
-#eval Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"] -- is the syntax of `Nat.add 1 1`
-#eval mkNode `«term_+_» #[Syntax.mkNumLit "1", mkAtom "+", Syntax.mkNumLit "1"] -- is the syntax for `1 + 1`
+#guard reprStr (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"]) == "{ raw := Lean.Syntax.node\n           (Lean.SourceInfo.none)\n           `Lean.Parser.Term.app\n           #[Lean.Syntax.ident (Lean.SourceInfo.none) \"Nat.add\".toSubstring `Nat.add [],\n             Lean.Syntax.node\n               (Lean.SourceInfo.none)\n               `null\n               #[Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"],\n                 Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"]]] }" -- is the syntax of `Nat.add 1 1`
+#guard reprStr (mkNode `«term_+_» #[Syntax.mkNumLit "1", mkAtom "+", Syntax.mkNumLit "1"]) == "{ raw := Lean.Syntax.node\n           (Lean.SourceInfo.none)\n           `«term_+_»\n           #[Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"],\n             Lean.Syntax.atom (Lean.SourceInfo.none) \"+\",\n             Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"]] }" -- is the syntax for `1 + 1`
 
 -- note that the `«term_+_» is the auto-generated SyntaxNodeKind for the + syntax
 
@@ -390,8 +401,8 @@ def isAdd11 : Syntax → Bool
   | `(Nat.add 1 1) => true
   | _ => false
 
-#eval isAdd11 (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"]) -- true
-#eval isAdd11 (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"]) -- false
+#guard reprStr (isAdd11 (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"])) == "true" -- true
+#guard reprStr (isAdd11 (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"])) == "false" -- false
 
 /-!
 The next level with matches is to capture variables from the input instead
@@ -402,9 +413,9 @@ def isAdd : Syntax → Option (Syntax × Syntax)
   | `(Nat.add $x $y) => some (x, y)
   | _ => none
 
-#eval isAdd (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"]) -- some ...
-#eval isAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"]) -- some ...
-#eval isAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo]) -- none
+#guard reprStr (isAdd (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"])) == "some (Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"],\n Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"])" -- some ...
+#guard reprStr (isAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"])) == "some (Lean.Syntax.ident (Lean.SourceInfo.none) \"foo\".toSubstring `foo [],\n Lean.Syntax.node (Lean.SourceInfo.none) `num #[Lean.Syntax.atom (Lean.SourceInfo.none) \"1\"])" -- some ...
+#guard reprStr (isAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo])) == "none" -- none
 
 /-!
 ### Typed Syntax
@@ -426,8 +437,8 @@ def isLitAdd : TSyntax `term → Option Nat
   | `(Nat.add $x:num $y:num) => some (x.getNat + y.getNat)
   | _ => none
 
-#eval isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"]) -- some 2
-#eval isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"]) -- none
+#guard reprStr (isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[Syntax.mkNumLit "1", Syntax.mkNumLit "1"])) == "some 2" -- some 2
+#guard reprStr (isLitAdd (Syntax.mkApp (mkIdent `Nat.add) #[mkIdent `foo, Syntax.mkNumLit "1"])) == "none" -- none
 
 /-!
 If you want to access the `Syntax` behind a `TSyntax` you can do this using
@@ -466,6 +477,8 @@ def test : Elab.TermElabM Nat := do
   let stx ← `(arith| (12 + 3) - 4)
   pure (denoteArith stx)
 
+/-- info: 11 -/
+#guard_msgs in --#
 #eval test -- 11
 
 /-!
@@ -547,6 +560,10 @@ basic version of our notation:
 -/
 notation "{ " x " | " p " }" => setOf (fun x => p)
 
+/--
+info: { x | x ≤ 1 } : Set Nat
+-/
+#guard_msgs in --#
 #check { (x : Nat) | x ≤ 1 } -- { x | x ≤ 1 } : Set Nat
 
 example : 1 ∈ { (y : Nat) | y ≤ 1 } := by simp[Membership.mem, Set.mem, setOf]

--- a/lean/main/06_macros.lean
+++ b/lean/main/06_macros.lean
@@ -24,10 +24,10 @@ syntax:10 (name := lxor) term:10 " LXOR " term:11 : term
   | `($l:term LXOR $r:term) => `(!$l && $r) -- we can use the quotation mechanism to create `Syntax` in macros
   | _ => Macro.throwUnsupported
 
-#eval true LXOR true -- false
-#eval true LXOR false -- false
-#eval false LXOR true -- true
-#eval false LXOR false -- false
+#guard reprStr (true LXOR true) == "false" -- false
+#guard reprStr (true LXOR false) == "false" -- false
+#guard reprStr (false LXOR true) == "true" -- true
+#guard reprStr (false LXOR false) == "false" -- false
 
 /-
 That was quite easy! The `Macro.throwUnsupported` function can be used by a macro
@@ -47,8 +47,8 @@ is it does not `Macro.throwUnsupported`. Let's see this in action:
   | `(true LXOR true) => `(true)
   | _ => Macro.throwUnsupported
 
-#eval true LXOR true -- true, handled by new macro
-#eval true LXOR false -- false, still handled by the old
+#guard reprStr (true LXOR true) == "true" -- true, handled by new macro
+#guard reprStr (true LXOR false) == "false" -- false, still handled by the old
 
 /-
 This capability is obviously *very* powerful! It should not be used
@@ -57,10 +57,10 @@ behaviour while writing code later on. The following example illustrates
 this weird behaviour:
 -/
 
-#eval true LXOR true -- true, handled by new macro
+#guard reprStr (true LXOR true) == "true" -- true, handled by new macro
 
 def foo := true
-#eval foo LXOR foo -- false, handled by old macro, after all the identifiers have a different name
+#guard reprStr (foo LXOR foo) == "false" -- false, handled by old macro, after all the identifiers have a different name
 
 /-
 Without knowing exactly how this macro is implemented this behaviour
@@ -102,10 +102,10 @@ If this is still not short enough for you, there is a next step using the
 
 macro l:term:10 " ⊕ " r:term:11 : term => `((!$l && $r) || ($l && !$r))
 
-#eval true ⊕ true -- false
-#eval true ⊕ false -- true
-#eval false ⊕ true -- true
-#eval false ⊕ false -- false
+#guard reprStr (true ⊕ true) == "false" -- false
+#guard reprStr (true ⊕ false) == "true" -- true
+#guard reprStr (false ⊕ true) == "true" -- true
+#guard reprStr (false ⊕ false) == "false" -- false
 
 /-
 As you can see, `macro` is quite close to `notation` already:
@@ -154,6 +154,10 @@ compiler, you could also declare functions that are specific to certain
 `TSyntax` variants. For example as we have seen in the syntax chapter
 there exists the function:
 -/
+/--
+info: Lean.TSyntax.getNat (s : NumLit) : Nat
+-/
+#guard_msgs in --#
 #check TSyntax.getNat -- TSyntax.getNat : TSyntax numLitKind → Nat
 /-!
 Which is guaranteed to not panic because we know that the `Syntax` that
@@ -205,7 +209,15 @@ macro_rules
   | `(cut_tuple ($x, $y)) => `(($x, $y))
   | `(cut_tuple ($x, $y, $xs,*)) => `(($y, $xs,*))
 
+/--
+info: (1, 2) : Nat × Nat
+-/
+#guard_msgs in --#
 #check cut_tuple (1, 2) -- (1, 2) : Nat × Nat
+/--
+info: (2, 3) : Nat × Nat
+-/
+#guard_msgs in --#
 #check cut_tuple (1, 2, 3) -- (2, 3) : Nat × Nat
 
 /-!
@@ -238,8 +250,8 @@ involve anti quotation variables involved here". So now we can run
 this syntax both with and without type ascription:
 -/
 
-#eval mylet x := 5 in x - 10 -- 0, due to subtraction behaviour of `Nat`
-#eval mylet x : Int := 5 in x - 10 -- -5, after all it is an `Int` now
+#guard reprStr (mylet x := 5 in x - 10) == "0" -- 0, due to subtraction behaviour of `Nat`
+#guard reprStr (mylet x : Int := 5 in x - 10) == "-5" -- -5, after all it is an `Int` now
 
 /-!
 The second and last splice might remind readers of list comprehension
@@ -253,7 +265,7 @@ syntax "foreach " "[" term,* "]" term : term
 macro_rules
   | `(foreach [ $[$x:term],* ] $func:term) => `(let f := $func; [ $[f $x],* ])
 
-#eval foreach [1,2,3,4] (Nat.add 2) -- [3, 4, 5, 6]
+#guard reprStr (foreach [1,2,3,4] (Nat.add 2)) == "[3, 4, 5, 6]" -- [3, 4, 5, 6]
 
 /-!
 In this case the `$[...],*` part is the splice. On the match side it tries
@@ -280,7 +292,7 @@ macro "const" e:term : term => `(fun x => $e)
 def x : Nat := 42
 
 -- Which `x` should be used by the compiler in place of `$e`?
-#eval (const x) 10 -- 42
+#guard reprStr ((const x) 10) == "42" -- 42
 
 /-
 Given the fact that macros perform only syntactic translations one might
@@ -436,7 +448,7 @@ macro_rules
   | `([Arith| $x:arith - $y:arith]) => `([Arith| $x] - [Arith| $y])
   | `([Arith| ($x:arith)]) => `([Arith| $x])
 
-#eval [Arith| (12 + 3) - 4] -- 11
+#guard reprStr ([Arith| (12 + 3) - 4]) == "11" -- 11
 
 /-! Again feel free to play around with it. If you want to build more complex
 things, like expressions with variables, maybe consider building an inductive type
@@ -494,6 +506,10 @@ macro_rules
   | `({ $var:ident ∈ $s:term | $body:term }) => `(setOf (fun $var => $var ∈ $s ∧ $body))
 
 -- Old examples with better syntax:
+/--
+info: setOf fun x => x ≤ 1 : Set Nat
+-/
+#guard_msgs in --#
 #check { x : Nat | x ≤ 1 } -- setOf fun x => x ≤ 1 : Set Nat
 
 example : 1 ∈ { y : Nat | y ≤ 1 } := by simp[Membership.mem, Set.mem, setOf]
@@ -501,6 +517,10 @@ example : 2 ∈ { y : Nat | y ≤ 3 ∧ 1 ≤ y } := by simp[Membership.mem, Set
 
 -- New examples:
 def oneSet : Set Nat := λ x => x = 1
+/--
+info: setOf fun x => x ∈ oneSet ∧ 10 ≤ x : Set Nat
+-/
+#guard_msgs in --#
 #check { x ∈ oneSet | 10 ≤ x } -- setOf fun x => x ∈ oneSet ∧ 10 ≤ x : Set Nat
 
 example : ∀ x, ¬(x ∈ { y ∈ oneSet | y ≠ 1 }) := by

--- a/lean/main/07_elaboration.lean
+++ b/lean/main/07_elaboration.lean
@@ -139,8 +139,20 @@ This is actually extending the original `#check`
   else
     throwUnsupportedSyntax
 
+/--
+info: Got ya!
+-/
+#guard_msgs in --#
 #check mycheck -- Got ya!
+/--
+info: Specially elaborated string literal!: Hello : String
+-/
+#guard_msgs in --#
 #check "Hello" -- Specially elaborated string literal!: Hello : String
+/--
+info: Nat.add : Nat → Nat → Nat
+-/
+#guard_msgs in --#
 #check Nat.add -- Nat.add : Nat → Nat → Nat
 
 /-!
@@ -235,6 +247,12 @@ At some point, execution of postponed metavariables will be resumed by the term 
 in hopes that it can now complete its execution. We can try to see this in
 action with the following example:
 -/
+/--
+info: List.foldr Nat.add 0 [1, 2, 3] : Nat
+---
+info: [Elab.postpone] .add : ?m.2639 → ?m.2640 → ?m.2640
+-/
+#guard_msgs in --#
 #check set_option trace.Elab.postpone true in List.foldr .add 0 [1,2,3] -- [Elab.postpone] .add : ?m.5695 → ?m.5696 → ?m.5696
 
 /-!
@@ -282,13 +300,13 @@ def mytermValues := [1, 2]
 def myTerm1Impl : TermElab := fun stx type? => do
   mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 0] -- `MetaM` code
 
-#eval myterm_1 -- 1
+#guard reprStr (myterm_1) == "1" -- 1
 
 -- Also works with `elab`
 elab "myterm_2" : term => do
   mkAppM ``List.get! #[.const ``mytermValues [], mkNatLit 1] -- `MetaM` code
 
-#eval myterm_2 -- 2
+#guard reprStr (myterm_2) == "2" -- 2
 
 /-!
 ### Mini project
@@ -327,6 +345,10 @@ def myanonImpl : TermElab := fun stx typ? => do
   let stx ← `($(mkIdent ctor) $args*) -- syntax quotations
   elabTerm stx typ -- call term elaboration recursively
 
+/--
+info: ⟨1, ⋯⟩ : Fin 12
+-/
+#guard_msgs in --#
 #check (⟨⟨1, sorry⟩⟩ : Fin 12) -- { val := 1, isLt := (_ : 1 < 12) } : Fin 12
 #check_failure ⟨⟨1, sorry⟩⟩ -- expected type must be known
 #check_failure (⟨⟨0⟩⟩ : Nat) -- type doesn't have exactly one constructor

--- a/lean/main/09_tactics.lean
+++ b/lean/main/09_tactics.lean
@@ -564,6 +564,10 @@ Lean.Elab.Tactic.evalTactic (← `(tactic| try rfl))
 A: Use `Lean.Meta.isExprDefEq <expr-1> <expr-2>`.
 -/
 
+/--
+info: Lean.Meta.isExprDefEq (t s : Lean.Expr) : Lean.MetaM Bool
+-/
+#guard_msgs in --#
 #check Lean.Meta.isExprDefEq
 -- Lean.Meta.isExprDefEq : Lean.Expr → Lean.Expr → Lean.MetaM Bool
 

--- a/lean/solutions/03_expressions.lean
+++ b/lean/solutions/03_expressions.lean
@@ -9,6 +9,10 @@ def one : Expr :=
   Expr.app (Expr.app (Expr.const `Nat.add []) (mkNatLit 1)) (mkNatLit 2)
 
 elab "one" : term => return one
+/--
+info: Nat.add 1 2 : Nat
+-/
+#guard_msgs in --#
 #check one  -- Nat.add 1 2 : Nat
 #reduce one -- 3
 
@@ -17,6 +21,10 @@ def two : Expr :=
   Lean.mkAppN (Expr.const `Nat.add []) #[mkNatLit 1, mkNatLit 2]
 
 elab "two" : term => return two
+/--
+info: Nat.add 1 2 : Nat
+-/
+#guard_msgs in --#
 #check two  -- Nat.add 1 2 : Nat
 #reduce two -- 3
 
@@ -27,6 +35,10 @@ def three : Expr :=
   BinderInfo.default
 
 elab "three" : term => return three
+/--
+info: fun x => Nat.add 1 x : Nat → Nat
+-/
+#guard_msgs in --#
 #check three    -- fun x => Nat.add 1 x : Nat → Nat
 #reduce three 6 -- 7
 
@@ -52,6 +64,10 @@ def four : Expr :=
   BinderInfo.default
 
 elab "four" : term => return four
+/--
+info: fun a b c => (b.mul a).add c : Nat → Nat → Nat → Nat
+-/
+#guard_msgs in --#
 #check four -- fun a b c => Nat.add (Nat.mul b a) c : Nat → Nat → Nat → Nat
 #reduce four 666 1 2 -- 668
 
@@ -66,6 +82,10 @@ def five :=
   BinderInfo.default
 
 elab "five" : term => return five
+/--
+info: fun x y => x.add y : Nat → Nat → Nat
+-/
+#guard_msgs in --#
 #check five      -- fun x y => Nat.add x y : Nat → Nat → Nat
 #reduce five 4 5 -- 9
 
@@ -76,8 +96,12 @@ def six :=
   BinderInfo.default
 
 elab "six" : term => return six
+/--
+info: fun x => "Hello, ".append x : String → String
+-/
+#guard_msgs in --#
 #check six        -- fun x => String.append "Hello, " x : String → String
-#eval six "world" -- "Hello, world"
+#guard reprStr (six "world") == "\"Hello, world\"" -- "Hello, world"
 
 /- ### 7. -/
 def seven : Expr :=
@@ -86,6 +110,10 @@ def seven : Expr :=
   BinderInfo.default
 
 elab "seven" : term => return seven
+/--
+info: ∀ (x : Prop), x ∧ x : Prop
+-/
+#guard_msgs in --#
 #check seven  -- ∀ (x : Prop), x ∧ x : Prop
 #reduce seven -- ∀ (x : Prop), x ∧ x
 
@@ -96,6 +124,10 @@ def eight : Expr :=
   BinderInfo.default
 
 elab "eight" : term => return eight
+/--
+info: Nat → String : Type
+-/
+#guard_msgs in --#
 #check eight  -- Nat → String : Type
 #reduce eight -- Nat → String
 
@@ -110,6 +142,10 @@ def nine : Expr :=
   BinderInfo.default
 
 elab "nine" : term => return nine
+/--
+info: fun p hP => hP : ∀ (p : Prop), p → p
+-/
+#guard_msgs in --#
 #check nine  -- fun p hP => hP : ∀ (p : Prop), p → p
 #reduce nine -- fun p hP => hP
 
@@ -118,5 +154,9 @@ def ten : Expr :=
   Expr.sort (Nat.toLevel 7)
 
 elab "ten" : term => return ten
+/--
+info: Type 6 : Type 7
+-/
+#guard_msgs in --#
 #check ten  -- Type 6 : Type 7
 #reduce ten -- Type 6

--- a/lean/solutions/04_metam.lean
+++ b/lean/solutions/04_metam.lean
@@ -5,6 +5,11 @@ open Lean Meta
 
 /- ### 1. -/
 
+/--
+info: value in hi: ?_uniq.958
+value in hi: Nat.succ Nat.zero
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let hi ← Lean.Meta.mkFreshExprMVar (Expr.const `Nat []) (userName := `hi)
   IO.println s!"value in hi: {← instantiateMVars hi}" -- ?_uniq.1
@@ -15,12 +20,20 @@ open Lean Meta
 /- ### 2. -/
 
 -- It would output the same expression we gave it - there were no metavariables to instantiate.
+/--
+info: fun (x : Nat) => x
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let instantiatedExpr ← instantiateMVars (Expr.lam `x (Expr.const `Nat []) (Expr.bvar 0) BinderInfo.default)
   IO.println instantiatedExpr -- fun (x : Nat) => x
 
 /- ### 3. -/
 
+/--
+info: Nat.add (Nat.add (Nat.succ (Nat.succ Nat.zero)) ?_uniq.2346) (Nat.succ Nat.zero)
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let oneExpr := Expr.app (Expr.const `Nat.succ []) (Expr.const ``Nat.zero [])
   let twoExpr := Expr.app (Expr.const `Nat.succ []) oneExpr
@@ -86,18 +99,34 @@ theorem redSolved (hA : 1 = 1) (hB : 2 = 2) : 2 = 2 := by
 
 def sixA : Bool → Bool := fun x => x
 -- .lam `x (.const `Bool []) (.bvar 0) (Lean.BinderInfo.default)
+/--
+info: Lean.Expr.lam `x (Lean.Expr.const `Bool []) (Lean.Expr.bvar 0) (Lean.BinderInfo.default)
+-/
+#guard_msgs in --#
 #eval Lean.Meta.reduce (Expr.const `sixA [])
 
 def sixB : Bool := (fun x => x) ((true && false) || true)
 -- .const `Bool.true []
+/--
+info: Lean.Expr.const `Bool.true []
+-/
+#guard_msgs in --#
 #eval Lean.Meta.reduce (Expr.const `sixB [])
 
 def sixC : Nat := 800 + 2
 -- .lit (Lean.Literal.natVal 802)
+/--
+info: Lean.Expr.lit (Lean.Literal.natVal 802)
+-/
+#guard_msgs in --#
 #eval Lean.Meta.reduce (Expr.const `sixC [])
 
 /- ### 7. -/
 
+/--
+info: true
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let litExpr := Expr.lit (Lean.Literal.natVal 1)
   let standardExpr := Expr.app (Expr.const ``Nat.succ []) (Expr.const ``Nat.zero [])
@@ -110,6 +139,10 @@ def sixC : Nat := 800 + 2
 -- a) `5 =?= (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))`
 -- Definitionally equal.
 def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
+/--
+info: true
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let expr1 := Lean.mkNatLit 5
   let expr2 := Expr.const `expr2 []
@@ -118,6 +151,10 @@ def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
 
 -- b) `2 + 1 =?= 1 + 2`
 -- Definitionally equal.
+/--
+info: true
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let expr1 := Lean.mkAppN (Expr.const `Nat.add []) #[Lean.mkNatLit 2, Lean.mkNatLit 1]
   let expr2 := Lean.mkAppN (Expr.const `Nat.add []) #[Lean.mkNatLit 1, Lean.mkNatLit 2]
@@ -126,6 +163,10 @@ def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
 
 -- c) `?a =?= 2`, where `?a` has a type `String`
 -- Not definitionally equal.
+/--
+info: false
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let expr1 ← Lean.Meta.mkFreshExprMVar (Expr.const `String []) (userName := `expr1)
   let expr2 := Lean.mkNatLit 2
@@ -135,6 +176,12 @@ def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
 -- d) `?a + Int =?= "hi" + ?b`, where `?a` and `?b` don't have a type
 -- Definitionally equal.
 -- `?a` is assigned to `"hi"`, `?b` is assigned to `Int`.
+/--
+info: true
+a: "hi"
+b: Int
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let a ← Lean.Meta.mkFreshExprMVar Option.none (userName := `a)
   let b ← Lean.Meta.mkFreshExprMVar Option.none (userName := `b)
@@ -148,6 +195,10 @@ def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
 
 -- e) `2 + ?a =?= 3`
 -- Not definitionally equal.
+/--
+info: false
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let a ← Lean.Meta.mkFreshExprMVar (Expr.const `Nat []) (userName := `a)
   let expr1 := Lean.mkAppN (Expr.const `Nat.add []) #[Lean.mkNatLit 2, a]
@@ -158,6 +209,11 @@ def expr2 := (fun x => 5) ((fun y : Nat → Nat => y) (fun z : Nat => z))
 -- f) `2 + ?a =?= 2 + 1`
 -- Definitionally equal.
 -- `?a` is assigned to `1`.
+/--
+info: true
+a: OfNat.ofNat.{0} Nat 1 (instOfNatNat 1)
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let a ← Lean.Meta.mkFreshExprMVar (Expr.const `Nat []) (userName := `a)
   let expr1 := Lean.mkAppN (Expr.const `Nat.add []) #[Lean.mkNatLit 2, a]
@@ -175,6 +231,14 @@ def defaultDef                    : Nat := 3
 
 @[reducible] def sum := [reducibleDef, instanceDef, defaultDef, irreducibleDef]
 
+/--
+info: [1, instanceDef, defaultDef, irreducibleDef]
+[1, 2, defaultDef, irreducibleDef]
+[1, 2, 3, irreducibleDef]
+[1, 2, 3, 4]
+[1, 2, 3, irreducibleDef]
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let constantExpr := Expr.const `sum []
 
@@ -213,8 +277,16 @@ def tenB : MetaM Expr := do
     Lean.Meta.mkLambdaFVars #[x] body
   )
 
+/--
+info: fun x => Nat.add 1 x
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← tenA) -- fun x => Nat.add 1 x
+/--
+info: fun x => Nat.add 1 x
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← tenB) -- fun x => Nat.add 1 x
 
@@ -223,6 +295,10 @@ def tenB : MetaM Expr := do
 def eleven : MetaM Expr :=
   return Expr.forallE `yellow (Expr.const `Nat []) (Expr.bvar 0) BinderInfo.default
 
+/--
+info: forall (yellow : Nat), yellow
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   dbg_trace (← eleven) -- forall (yellow : Nat), yellow
 
@@ -245,9 +321,17 @@ def twelveB : MetaM Expr := do
     forAll
   )
 
+/--
+info: (n : Nat) → Eq Nat n (n.add 1)
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← twelveA) -- (n : Nat) → Eq Nat n (Nat.add n 1)
 
+/--
+info: ∀ (n : Nat), n = n.add 1
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← twelveB) -- ∀ (n : Nat), n = Nat.add n 1
 
@@ -265,11 +349,21 @@ def thirteen : MetaM Expr := do
     lam
   )
 
+/--
+info: fun f => (n : Nat) → Eq Nat (f n) (f (n.add 1))
+-/
+#guard_msgs in --#
 #eval show MetaM _ from do
   ppExpr (← thirteen) -- fun f => (n : Nat) → Eq Nat (f n) (f (Nat.add n 1))
 
 /- ### 14. -/
 
+/--
+info: And ?_uniq.18260 ?_uniq.18260
+(Or ?_uniq.18264 ?_uniq.18265) -> ?_uniq.18265 -> (And ?_uniq.18264 ?_uniq.18264)
+forall (a._@.solutions.04_metam._hyg.3000 : Prop) (b._@.solutions.04_metam._hyg.3000 : Prop), (Or a._@.solutions.04_metam._hyg.3000 b._@.solutions.04_metam._hyg.3000) -> b._@.solutions.04_metam._hyg.3000 -> (And a._@.solutions.04_metam._hyg.3000 a._@.solutions.04_metam._hyg.3000)
+-/
+#guard_msgs in --#
 #eval show Lean.Elab.Term.TermElabM _ from do
   let stx : Syntax ← `(∀ (a : Prop) (b : Prop), a ∨ b → b → a ∧ a)
   let expr ← Elab.Term.elabTermAndSynthesize stx none
@@ -285,6 +379,22 @@ def thirteen : MetaM Expr := do
 
 /- ### 15. -/
 
+/--
+info: value in c: Nat.add ?_uniq.20812 Int
+value in d: Nat.add "hi" ?_uniq.20813
+
+Saved state
+
+true
+value in c: Nat.add "hi" Int
+value in d: Nat.add "hi" Int
+
+Restored state
+
+value in c: Nat.add ?_uniq.20812 Int
+value in d: Nat.add "hi" ?_uniq.20813
+-/
+#guard_msgs in --#
 #eval show MetaM Unit from do
   let a ← Lean.Meta.mkFreshExprMVar (Expr.const `String []) (userName := `a)
   let b ← Lean.Meta.mkFreshExprMVar (Expr.sort (Nat.toLevel 1)) (userName := `b)

--- a/lean/solutions/05_syntax.lean
+++ b/lean/solutions/05_syntax.lean
@@ -82,7 +82,7 @@ syntax (name := bigsumin) "∑ " Batteries.ExtendedBinder.extBinder "in " term "
 def elabSum : TermElab := fun stx tp =>
   return mkNatLit 666
 
-#eval ∑ x in { 1, 2, 3 }, x^2
+#guard reprStr (∑ x in { 1, 2, 3 }, x^2) == "666"
 
 def hi := (∑ x in { "apple", "banana", "cherry" }, x.length) + 1
-#eval hi
+#guard reprStr (hi) == "667"

--- a/lean/solutions/07_elaboration.lean
+++ b/lean/solutions/07_elaboration.lean
@@ -15,9 +15,9 @@ elab n:term "♥" a:"♥"? b:"♥"? : term => do
   else
     return Expr.app (Expr.app (Expr.const `Nat.add []) nExpr) (mkNatLit 1)
 
-#eval 7 ♥ -- 8
-#eval 7 ♥♥ -- 9
-#eval 7 ♥♥♥ -- 10
+#guard reprStr (7 ♥) == "8" -- 8
+#guard reprStr (7 ♥♥) == "9" -- 9
+#guard reprStr (7 ♥♥♥) == "10" -- 10
 
 /- ### 2. -/
 


### PR DESCRIPTION
Closes #188.

## What changed

- replace plain value evaluations with `#guard` output assertions
- guard evaluator-driven `MetaM` and `TermElabM` examples with exact `#guard_msgs` contracts
- add exact `#guard_msgs` assertions to every `#check` example
- preserve the pedagogical traces while making their observable output regression-tested

## Validation

- `lake build` (23 targets)
- structural audit: every remaining `#eval` and every `#check` is directly guarded
- `git diff --check`